### PR TITLE
Hide announcements if users closes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.1.2 - 2024-04-26
+
+New features:
+ - Hide announcements if users closes them [#7](https://github.com/okfn/ckanext-announcements/pull/7)
+Bug fixes:
+ - Do not send the SQLAlchemy objects to template [#7](https://github.com/okfn/ckanext-announcements/pull/7)
+
 ## 0.1.1 - 2024-04-23
 
 New features:

--- a/ckanext/announcements/assets/css/announcements.css
+++ b/ckanext/announcements/assets/css/announcements.css
@@ -7,6 +7,7 @@ Public
 }
 
 .announcement {
+  display: none; /* All is hide until is not hide */
   padding-bottom: 20px;
   margin-bottom: 10px;
 }

--- a/ckanext/announcements/assets/js/announcements.js
+++ b/ckanext/announcements/assets/js/announcements.js
@@ -26,5 +26,37 @@ $( document ).ready(function() {
     // hide error div on modal hide to start fresh next time
     $('.announcement-form-modal').on('hide.bs.modal', function () {
         $('.announcement-form-error').hide();
-    })
+    });
+
+    // add a cookie to remember if user closed any announcement
+    $(document).on('click', '.announcement-close-button', function(e) {
+        var announcement_id = $(this).data('announcement-id');
+        var storage_name = 'announcement_closed_' + announcement_id;
+        var expirationDate = new Date();
+        expirationDate.setDate(expirationDate.getDate() + 30);  // Set expiration date to 7 days from now
+        var item = {
+            value: 'true',
+            expiry: expirationDate.getTime()
+        };
+        localStorage.setItem(storage_name, JSON.stringify(item));
+    });
+
+    // Show announcements that haven't been previously closed by the user
+    $('.announcement').each(function(i, obj) {
+        var announcement_id = $(obj).data('announcement-id');
+        var storage_name = 'announcement_closed_' + announcement_id;
+        var st = localStorage.getItem(storage_name);
+        var now = new Date();
+        if (st === null ) {
+            // If the item is not in the storage show the announcement
+            $(obj).show();
+        }
+        // remove the storage key if expired
+        else {
+            var item = JSON.parse(localStorage.getItem(storage_name));
+            if (now.getTime() > item.expiry) {
+                localStorage.removeItem(storage_name);
+            }
+        }
+    });
 });

--- a/ckanext/announcements/helpers.py
+++ b/ckanext/announcements/helpers.py
@@ -42,7 +42,10 @@ def _apply_tz(messages):
     """Apply the timezone to the messages"""
     display_timezone = toolkit.config.get("ckan.display_timezone", "UTC")
     tz = timezone(display_timezone)
+    # Do not send the SQLAlchemy objects to template, use dictionaries instead
+    dict_messages = []
     for message in messages:
         message.from_date = message.from_date.astimezone(tz)
         message.to_date = message.to_date.astimezone(tz)
-    return messages
+        dict_messages.append(message.dictize())
+    return dict_messages

--- a/ckanext/announcements/helpers.py
+++ b/ckanext/announcements/helpers.py
@@ -20,7 +20,7 @@ def get_public_announcements():
         .limit(10)
         .all()
     )
-    messages = _apply_tz(messages)
+    messages = dictize_announ(messages)
     return messages
 
 
@@ -34,12 +34,12 @@ def get_all_announcements():
         .limit(limit)
         .all()
     )
-    messages = _apply_tz(messages)
+    messages = dictize_announ(messages)
     return messages
 
 
-def _apply_tz(messages):
-    """Apply the timezone to the messages"""
+def dictize_announ(messages):
+    """Dictize and improve. Apply the proper timezone to messages"""
     display_timezone = toolkit.config.get("ckan.display_timezone", "UTC")
     tz = timezone(display_timezone)
     # Do not send the SQLAlchemy objects to template, use dictionaries instead

--- a/ckanext/announcements/templates/announcements/announcement.html
+++ b/ckanext/announcements/templates/announcements/announcement.html
@@ -1,7 +1,7 @@
 <div class="announcements-container container">
     {% for announcement in h.get_public_announcements() %}
-        <div class="alert alert-warning alert-dismissible announcement" role="alert" >
-           <button type="button" class="close" data-bs-dismiss="alert" data-dismiss="alert" aria-label="Close">
+        <div class="alert alert-warning alert-dismissible announcement" data-announcement-id="{{ announcement.id }}" role="alert" >
+           <button type="button" class="close announcement-close-button" data-announcement-id="{{ announcement.id }}" data-bs-dismiss="alert" data-dismiss="alert" aria-label="Close">
 			    <span aria-hidden="true">&times;</span>
 			  </button>
 

--- a/ckanext/announcements/tests/test_plugin.py
+++ b/ckanext/announcements/tests/test_plugin.py
@@ -42,4 +42,4 @@ class TestAnnouncements:
         """Test public messages helper"""
         ga = get_public_announcements()
         assert len(ga) == 1
-        assert ga[0].message == "This should be a public message"
+        assert ga[0]['message'] == "This should be a public message"


### PR DESCRIPTION
This PR uses the local storage to know if an announcements was closed by user

Extras:
 - Do not send SQLAlchemy objects to template as CKAN recommends
