### PR TITLE
Fix missing block

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
--   repo: https://gitlab.com/pycqa/flake8
-    rev: 3.7.9
+-   repo: https://github.com/PyCQA/flake8
+    rev: 7.0.0
     hooks:
     - id: flake8
       files: ckanext

--- a/ckanext/announcements/templates/admin/announcements.html
+++ b/ckanext/announcements/templates/admin/announcements.html
@@ -46,10 +46,7 @@
   </tbody>
 </table>
 </div>
-{% endblock %}
 
-{% block body_extras %}
-{{ super() }}
 {% include "admin/snippets/new-announcement.html" %}
 
 {% for message in messages %}


### PR DESCRIPTION
CKAN core 2.11 decided to drop a block in template

Also, flak8 decided to drop the public GitLab repo we use for pre-commits